### PR TITLE
Adjusting window depending on taskbar location plus minor fixes

### DIFF
--- a/Volumey/View/MainView.xaml
+++ b/Volumey/View/MainView.xaml
@@ -28,7 +28,7 @@
                   BorderThickness="0"
                   IsVisibleChanged="OnIsVisibleChanged"
                   PreviewKeyDown="OnKeyDown"
-                  Loaded="OnLoaded">
+                  Loaded="OnLoaded" ShowInTaskbar="False" ResizeMode="NoResize">
 
     <fw:AcrylicWindow.DataContext>
         <viewModel:MainViewModel />
@@ -41,18 +41,18 @@
                 Command="{Binding Path=ClosingCommand}"
                 PassEventArgsToCommand="True" />
         </behaviors:EventTrigger>
-        
+
         <behaviors:EventTrigger EventName="Deactivated" SourceObject="{Binding ElementName=Window}">
             <behaviors:InvokeCommandAction Command="{Binding Path=LostFocusCommand}" />
         </behaviors:EventTrigger>
-        
+
     </behaviors:Interaction.Triggers>
 
     <fw:AcrylicWindow.Resources>
         <ResourceDictionary>
             <converters:DeviceIsDefaultToIconConverter x:Key="DeviceIsDefaultToIconConverter"/>
             <converters:BrushToColorConverter x:Key="BrushToColorConverter"/>
-            
+
             <ContextMenu
                 x:Key="TrayMenu"
                 HasDropShadow="True"
@@ -80,7 +80,7 @@
                     <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="{Binding ElementName=GridContainer, Path=Background, Converter={StaticResource BrushToColorConverter}}"/>
                     <Thickness x:Key="MenuFlyoutPresenterBorderThemeThickness">0</Thickness>
                 </ContextMenu.Resources>
-                
+
                 <MenuItem
                     Header="{lc:Localization TabHeader_Mixer}"
                     Foreground="{Binding ElementName=Window, Path=Foreground}"
@@ -114,7 +114,7 @@
                         <ui:FontIcon Glyph="&#xE7F3;" />
                     </MenuItem.Icon>
                 </MenuItem>
-                
+
                 <MenuItem
                     Foreground="{Binding ElementName=Window, Path=Foreground}"
                     ItemsSource="{Binding Source={StaticResource DeviceProviderViewModel}, Path=DeviceProvider.ActiveDevices}"
@@ -152,7 +152,7 @@
                         </Style>
                     </MenuItem.ItemContainerStyle>
                 </MenuItem>
-                
+
                 <Separator />
                 <MenuItem
                     Header="{lc:Localization TrayMenu_Exit}"
@@ -181,15 +181,11 @@
 
         </ResourceDictionary>
     </fw:AcrylicWindow.Resources>
-    
-    <fw:AcrylicWindow.ShowInTaskbar>
-        <Binding Path="DisplayMinimalistic" Converter="{StaticResource InverseBoolConverter}"/>
-    </fw:AcrylicWindow.ShowInTaskbar>
 
     <fw:AcrylicWindow.Visibility>
         <Binding Path="WindowIsVisible" Converter="{StaticResource WindowVisibilityConverter}" />
     </fw:AcrylicWindow.Visibility>
-    
+
     <fw:AcrylicWindow.Topmost>
         <Binding Path="AlwaysOnTop"/>
     </fw:AcrylicWindow.Topmost>
@@ -198,11 +194,15 @@
         Name="GridContainer"
         Background="{DynamicResource SystemChromeMediumLowColorBrush}"
         Opacity="0.94">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="89*"/>
+            <RowDefinition Height="96*"/>
+        </Grid.RowDefinitions>
         <tb:TaskbarIcon
             Name="Tray"
             NoLeftClickDelay="True"
             LeftClickCommand="{Binding TrayClickCommand}"
-            ContextMenu="{StaticResource TrayMenu}">
+            ContextMenu="{StaticResource TrayMenu}" Grid.RowSpan="2">
 
             <tb:TaskbarIcon.IconSource>
                 <MultiBinding Converter="{StaticResource TrayIconConverter}">
@@ -256,7 +256,7 @@
             IsSettingsVisible="True"
             ItemInvoked="NavigationView_OnItemInvoked"
             IsBackEnabled="False"
-            IsBackButtonVisible="Collapsed">
+            IsBackButtonVisible="Collapsed" Grid.RowSpan="2">
 
             <ui:NavigationView.MenuItems>
 

--- a/Volumey/View/MainView.xaml
+++ b/Volumey/View/MainView.xaml
@@ -28,7 +28,7 @@
                   BorderThickness="0"
                   IsVisibleChanged="OnIsVisibleChanged"
                   PreviewKeyDown="OnKeyDown"
-                  Loaded="OnLoaded" ShowInTaskbar="False" ResizeMode="NoResize">
+                  Loaded="OnLoaded">
 
     <fw:AcrylicWindow.DataContext>
         <viewModel:MainViewModel />
@@ -182,6 +182,10 @@
         </ResourceDictionary>
     </fw:AcrylicWindow.Resources>
 
+    <fw:AcrylicWindow.ShowInTaskbar>
+        <Binding Path="DisplayMinimalistic" Converter="{StaticResource InverseBoolConverter}"/>
+    </fw:AcrylicWindow.ShowInTaskbar>
+
     <fw:AcrylicWindow.Visibility>
         <Binding Path="WindowIsVisible" Converter="{StaticResource WindowVisibilityConverter}" />
     </fw:AcrylicWindow.Visibility>
@@ -194,15 +198,11 @@
         Name="GridContainer"
         Background="{DynamicResource SystemChromeMediumLowColorBrush}"
         Opacity="0.94">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="89*"/>
-            <RowDefinition Height="96*"/>
-        </Grid.RowDefinitions>
         <tb:TaskbarIcon
             Name="Tray"
             NoLeftClickDelay="True"
             LeftClickCommand="{Binding TrayClickCommand}"
-            ContextMenu="{StaticResource TrayMenu}" Grid.RowSpan="2">
+            ContextMenu="{StaticResource TrayMenu}">
 
             <tb:TaskbarIcon.IconSource>
                 <MultiBinding Converter="{StaticResource TrayIconConverter}">
@@ -256,7 +256,7 @@
             IsSettingsVisible="True"
             ItemInvoked="NavigationView_OnItemInvoked"
             IsBackEnabled="False"
-            IsBackButtonVisible="Collapsed" Grid.RowSpan="2">
+            IsBackButtonVisible="Collapsed">
 
             <ui:NavigationView.MenuItems>
 

--- a/Volumey/View/MainView.xaml.cs
+++ b/Volumey/View/MainView.xaml.cs
@@ -107,7 +107,6 @@ namespace Volumey.View
 
 		private async void OnLoaded(object sender, RoutedEventArgs routedEventArgs)
 		{
-			GetTaskBarLocation();
 			SetWindowPosition();
 			#if(!DEBUG)
 			try
@@ -135,7 +134,6 @@ namespace Volumey.View
 				
 		            //update layout before setting windows position to use actual height of the window when calculating its position
 		            this.UpdateLayout();
-					this.GetTaskBarLocation();
 					this.SetWindowPosition();
 					this.Activate();
 					this.Focus();
@@ -157,7 +155,7 @@ namespace Volumey.View
 		}
 
 		/// <summary>
-		/// Move window to the right bottom corner of display
+		/// Move window to the right corner depending on the taskbar location
 		/// </summary>
 		private void SetWindowPosition()
 		{
@@ -168,29 +166,29 @@ namespace Volumey.View
 			{
 				case TaskBarLocation.TOP:
 
-					this.Left = SystemParameters.WorkArea.Right - this.ActualWidth;
-					topPos = SystemParameters.WorkArea.Top;
+					this.Left = SystemParameters.WorkArea.Right - this.ActualWidth - BorderIndent;
+					topPos = SystemParameters.WorkArea.Top + BorderIndent;
 					this.Top = topPos < 0 ? 0 : topPos;
 					break;
 
                 case TaskBarLocation.BOTTOM:
 
-                    this.Left = SystemParameters.WorkArea.Right - this.ActualWidth;
-                    topPos = SystemParameters.WorkArea.Bottom - this.ActualHeight;
+                    this.Left = SystemParameters.WorkArea.Right - this.ActualWidth - BorderIndent;
+                    topPos = SystemParameters.WorkArea.Bottom - this.ActualHeight - BorderIndent;
                     this.Top = topPos < 0 ? 0 : topPos;
                     break;
 
                 case TaskBarLocation.LEFT:
 
-                    this.Left = SystemParameters.WorkArea.Left;
-                    topPos = SystemParameters.WorkArea.Bottom - this.ActualHeight;
+                    this.Left = SystemParameters.WorkArea.Left + BorderIndent;
+                    topPos = SystemParameters.WorkArea.Bottom - this.ActualHeight - BorderIndent;
                     this.Top = topPos < 0 ? 0 : topPos;
                     break;
 
                 case TaskBarLocation.RIGHT:
 
-                    this.Left = SystemParameters.WorkArea.Right - this.ActualWidth;
-                    topPos = SystemParameters.WorkArea.Bottom - this.ActualHeight;
+                    this.Left = SystemParameters.WorkArea.Right - this.ActualWidth - BorderIndent;
+                    topPos = SystemParameters.WorkArea.Bottom - this.ActualHeight - BorderIndent;
                     this.Top = topPos < 0 ? 0 : topPos;
                     break;
             }
@@ -311,7 +309,6 @@ namespace Volumey.View
 			if(this.Visibility == Visibility.Visible && !this.positionChanged)
 			{
 				this.LimitWindowHeightIfNecessary();
-				this.GetTaskBarLocation();
 				this.SetWindowPosition();	
 			}
 		}

--- a/Volumey/View/MainView.xaml.cs
+++ b/Volumey/View/MainView.xaml.cs
@@ -107,6 +107,7 @@ namespace Volumey.View
 
 		private async void OnLoaded(object sender, RoutedEventArgs routedEventArgs)
 		{
+			GetTaskBarLocation();
 			SetWindowPosition();
 			#if(!DEBUG)
 			try
@@ -133,12 +134,26 @@ namespace Volumey.View
 		            this.LimitWindowHeightIfNecessary();
 				
 		            //update layout before setting windows position to use actual height of the window when calculating its position
-		            this.UpdateLayout(); 
-		            this.SetWindowPosition();
+		            this.UpdateLayout();
+					this.GetTaskBarLocation();
+					this.SetWindowPosition();
 					this.Activate();
 					this.Focus();
 	            }
             }
+		}
+
+		private enum TaskBarLocation { TOP, BOTTOM, LEFT, RIGHT }
+		private TaskBarLocation GetTaskBarLocation()
+		{
+			if (SystemParameters.WorkArea.Left > 0)
+				return TaskBarLocation.LEFT;
+			if (SystemParameters.WorkArea.Top > 0)
+				return TaskBarLocation.TOP;
+			if (SystemParameters.WorkArea.Left == 0
+			  && SystemParameters.WorkArea.Width < SystemParameters.PrimaryScreenWidth)
+				return TaskBarLocation.RIGHT;
+			return TaskBarLocation.BOTTOM;
 		}
 
 		/// <summary>
@@ -146,12 +161,41 @@ namespace Volumey.View
 		/// </summary>
 		private void SetWindowPosition()
 		{
-			var deskWorkArea = SystemParameters.WorkArea;
-			this.Left = deskWorkArea.Right - this.ActualWidth - BorderIndent;
-			var topPos = deskWorkArea.Bottom - this.ActualHeight - BorderIndent;
-			this.Top = topPos < 0 ? 0 : topPos;
-		}
-		
+			TaskBarLocation taskBarLocation = GetTaskBarLocation();
+			double topPos;
+
+			switch (taskBarLocation)
+			{
+				case TaskBarLocation.TOP:
+
+					this.Left = SystemParameters.WorkArea.Right - this.ActualWidth;
+					topPos = SystemParameters.WorkArea.Top;
+					this.Top = topPos < 0 ? 0 : topPos;
+					break;
+
+                case TaskBarLocation.BOTTOM:
+
+                    this.Left = SystemParameters.WorkArea.Right - this.ActualWidth;
+                    topPos = SystemParameters.WorkArea.Bottom - this.ActualHeight;
+                    this.Top = topPos < 0 ? 0 : topPos;
+                    break;
+
+                case TaskBarLocation.LEFT:
+
+                    this.Left = SystemParameters.WorkArea.Left;
+                    topPos = SystemParameters.WorkArea.Bottom - this.ActualHeight;
+                    this.Top = topPos < 0 ? 0 : topPos;
+                    break;
+
+                case TaskBarLocation.RIGHT:
+
+                    this.Left = SystemParameters.WorkArea.Right - this.ActualWidth;
+                    topPos = SystemParameters.WorkArea.Bottom - this.ActualHeight;
+                    this.Top = topPos < 0 ? 0 : topPos;
+                    break;
+            }
+        }
+
 		private void LimitWindowHeightIfNecessary()
 		{
 			var desktopHeight = SystemParameters.WorkArea.Height;
@@ -267,6 +311,7 @@ namespace Volumey.View
 			if(this.Visibility == Visibility.Visible && !this.positionChanged)
 			{
 				this.LimitWindowHeightIfNecessary();
+				this.GetTaskBarLocation();
 				this.SetWindowPosition();	
 			}
 		}


### PR DESCRIPTION
I came across your program looking for something to open the volume mixer directly, and gave it a try. However my problem was that my taskbar is on the top on my screen, and whenever I tried and opened the program it would show the window on the bottom right by default without an option to change it. Also, it would pop up the application's icon on taskbar each time I opened it. That made me decide to mess a bit with the code and to perform this changes: 

1. Firstly, a _getTaskBarLocation_ method was added to get the position of the taskbar and display it accordingly. It doesn't work with the taskbar hidden, but it does the job.
2. Icon doesn't show on taskbar every time the program is opened anymore.
3. The window was made non-resizable and with no padding from the border for a more seamless integration (looking to achieve the same aesthetic as the default volume bar).

[Sample screenshot](https://user-images.githubusercontent.com/35470264/145687227-c460bcb1-2bdc-473c-8105-7db5ab837064.png) taken with top bar placement.

Let me know if it needs some changes or something is not working as intented!