### PR TITLE
Misc feature to synchronise Master volume changes across all running processes

### DIFF
--- a/Volumey/DataProvider/AppSettings.cs
+++ b/Volumey/DataProvider/AppSettings.cs
@@ -73,8 +73,15 @@ namespace Volumey.DataProvider
 			get => volumeLimitIsOn;
 			set => volumeLimitIsOn = value;
 		}
+        [OptionalField]
+        private bool syncAppVolumeIsOn;
+        public bool SyncAppVolumeIsOn
+        {
+			get => syncAppVolumeIsOn;
+			set => syncAppVolumeIsOn = value;
+		}
 
-		[OptionalField]
+        [OptionalField]
 		private int volumeLimit = 50;
 		public int VolumeLimit
 		{

--- a/Volumey/Resources/Resources.Designer.cs
+++ b/Volumey/Resources/Resources.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Volumey.Resources {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -189,6 +189,15 @@ namespace Volumey.Resources {
         /// <summary>
         ///   Looks up a localized string similar to .
         /// </summary>
+        internal static string Notifications_ReactAll {
+            get {
+                return ResourceManager.GetString("Notifications_ReactAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
         internal static string Notifications_Time {
             get {
                 return ResourceManager.GetString("Notifications_Time", resourceCulture);
@@ -225,6 +234,15 @@ namespace Volumey.Resources {
         /// <summary>
         ///   Looks up a localized string similar to .
         /// </summary>
+        internal static string Settings_AddHotkey {
+            get {
+                return ResourceManager.GetString("Settings_AddHotkey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
         internal static string Settings_AlwaysTop {
             get {
                 return ResourceManager.GetString("Settings_AlwaysTop", resourceCulture);
@@ -237,6 +255,15 @@ namespace Volumey.Resources {
         internal static string Settings_AppsHotkeys {
             get {
                 return ResourceManager.GetString("Settings_AppsHotkeys", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Settings_AppVolumeSync {
+            get {
+                return ResourceManager.GetString("Settings_AppVolumeSync", resourceCulture);
             }
         }
         
@@ -324,6 +351,24 @@ namespace Volumey.Resources {
         /// <summary>
         ///   Looks up a localized string similar to .
         /// </summary>
+        internal static string Settings_ForegroundVolumeDown {
+            get {
+                return ResourceManager.GetString("Settings_ForegroundVolumeDown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Settings_ForegroundVolumeUp {
+            get {
+                return ResourceManager.GetString("Settings_ForegroundVolumeUp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
         internal static string Settings_HeaderHotkeys {
             get {
                 return ResourceManager.GetString("Settings_HeaderHotkeys", resourceCulture);
@@ -378,6 +423,42 @@ namespace Volumey.Resources {
         /// <summary>
         ///   Looks up a localized string similar to .
         /// </summary>
+        internal static string Settings_LastPosition {
+            get {
+                return ResourceManager.GetString("Settings_LastPosition", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Settings_LaunchStartup {
+            get {
+                return ResourceManager.GetString("Settings_LaunchStartup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Settings_MediaHotkeys {
+            get {
+                return ResourceManager.GetString("Settings_MediaHotkeys", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Settings_MediaReplace {
+            get {
+                return ResourceManager.GetString("Settings_MediaReplace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
         internal static string Settings_MixerSettings {
             get {
                 return ResourceManager.GetString("Settings_MixerSettings", resourceCulture);
@@ -423,6 +504,15 @@ namespace Volumey.Resources {
         /// <summary>
         ///   Looks up a localized string similar to .
         /// </summary>
+        internal static string Settings_PreventBalanceReset {
+            get {
+                return ResourceManager.GetString("Settings_PreventBalanceReset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
         internal static string Settings_RemoveApp {
             get {
                 return ResourceManager.GetString("Settings_RemoveApp", resourceCulture);
@@ -435,6 +525,33 @@ namespace Volumey.Resources {
         internal static string Settings_RemoveDevice {
             get {
                 return ResourceManager.GetString("Settings_RemoveDevice", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Settings_RemoveHotkey {
+            get {
+                return ResourceManager.GetString("Settings_RemoveHotkey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Settings_SelectedScreen {
+            get {
+                return ResourceManager.GetString("Settings_SelectedScreen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Settings_StartMenu {
+            get {
+                return ResourceManager.GetString("Settings_StartMenu", resourceCulture);
             }
         }
         

--- a/Volumey/Resources/Resources.en.resx
+++ b/Volumey/Resources/Resources.en.resx
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -255,5 +314,8 @@
   </data>
   <data name="Settings_PreventBalanceReset" xml:space="preserve">
     <value>Prevent resetting the volume balance by muting the device instead of setting the volume to 0</value>
+  </data>
+  <data name="Settings_AppVolumeSync" xml:space="preserve">
+    <value>Synchronise volume of all applications to Master</value>
   </data>
 </root>

--- a/Volumey/Resources/Resources.resx
+++ b/Volumey/Resources/Resources.resx
@@ -1,85 +1,187 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:element name="root" msdata:IsDataSet="true"></xsd:element>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
   </xsd:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
-    <value>1.3</value>
+    <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Settings_VolumeStep" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_OpenMixer" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_IncreaseHotkey" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_DecreaseHotkey" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_HeaderHotkeys" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_Theme" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_HeaderMisc" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_Lang" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="TrayMenu_SoundPanel" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="TrayMenu_SoundSettings" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="TrayMenu_Exit" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="TabHeader_Mixer" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="TabHeader_Settings" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_MusicApp" xml:space="preserve">
     <value />
   </data>
   <data name="Error_VolumeReg" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Error_Diff" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Error_OpenReg" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Notification_Yes" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Notification_No" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Notification_Later" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="NotificationMessage_Update" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Error_NoDevice" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Error_HotkeyExists" xml:space="preserve">
     <value />
@@ -109,67 +211,67 @@
     <value />
   </data>
   <data name="Settings_Tip" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_DefaultDeviceHotkey" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_AddDevice" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_RemoveDevice" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="TrayMenu_ChangeDevice" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_Device" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_Hotkey" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_BlockHotkeys" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_Duplicates" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_MuteDevice" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_Popup" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_AlwaysTop" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Status_Muted" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Notifications_Header" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Notifications_Position" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Notifications_Vertical" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Notifications_Horizontal" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Notifications_Preview" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Notifications_Time" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_DeviceBottom" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_DeviceIcon" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_MixerSettings" xml:space="preserve">
     <value />
@@ -178,39 +280,42 @@
     <value />
   </data>
   <data name="Settings_LaunchStartup" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_StartMenu" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_ForegroundVolumeUp" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_ForegroundVolumeDown" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_LastPosition" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_MediaHotkeys" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_MediaReplace" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_AddHotkey" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_RemoveHotkey" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Notifications_ReactAll" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_SelectedScreen" xml:space="preserve">
-    <value></value>
+    <value />
   </data>
   <data name="Settings_PreventBalanceReset" xml:space="preserve">
-    <value></value>
+    <value />
+  </data>
+  <data name="Settings_AppVolumeSync" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/Volumey/View/SettingsPage/MiscPage.xaml
+++ b/Volumey/View/SettingsPage/MiscPage.xaml
@@ -24,8 +24,8 @@
 		<StackPanel DataContext="{Binding VolumeLimitViewModel}">
 			<TextBlock Text="{lc:Localization Settings_VolumeLimit}"
 					   HorizontalAlignment="Left"/>
-			<StackPanel Orientation="Horizontal">
-				<ui:NumberBox Minimum="1"
+            <StackPanel Orientation="Horizontal">
+                <ui:NumberBox Minimum="1"
 							  Maximum="99"
 							  LargeChange="5"
 							  SmallChange="1"
@@ -35,16 +35,21 @@
 							  ValueChanged="NumberBox_OnValueChanged"
 							  Width="170"
 							  HorizontalAlignment="Left"/>
-				<TextBlock Text="%"
+                <TextBlock Text="%"
 						   HorizontalAlignment="Center"
 						   VerticalAlignment="Center"
 						   Margin="5 0 0 0"
 						   Width="Auto"/>
-			</StackPanel>
-			<ui:ToggleSwitch IsOn="{Binding IsOn}"/>
-		</StackPanel>
-		
-		<TextBlock Text="{lc:Localization Settings_VolumeStep}"/>
+            </StackPanel>
+            <ui:ToggleSwitch IsOn="{Binding IsOn}"/>
+        </StackPanel>
+        <StackPanel DataContext="{Binding AppVolumeSyncViewModel}">
+            <TextBlock Text="{lc:Localization Settings_AppVolumeSync}"
+					   />
+            <ui:ToggleSwitch IsOn="{Binding IsOn}"/>
+        </StackPanel>
+
+        <TextBlock Text="{lc:Localization Settings_VolumeStep}"/>
 		<ui:NumberBox Minimum="1"
 					  Maximum="100"
 					  LargeChange="5"

--- a/Volumey/ViewModel/Settings/AppVolumeSyncViewModel.cs
+++ b/Volumey/ViewModel/Settings/AppVolumeSyncViewModel.cs
@@ -1,0 +1,119 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using log4net;
+using Volumey.CoreAudioWrapper.Wrapper;
+using Volumey.DataProvider;
+using Volumey.Model;
+
+namespace Volumey.ViewModel.Settings
+{
+	public sealed class AppVolumeSyncViewModel : INotifyPropertyChanged
+	{
+		private int masterVolume = 100;
+		public int MasterVolume
+		{
+			get => masterVolume;
+		}
+        private bool isOn;
+		public bool IsOn
+		{
+			get => isOn;
+			set
+			{
+				isOn = value;
+				if(isOn)
+				{
+					this.deviceProvider.DefaultDeviceChanged += OnDefaultDeviceChanged;
+					this.defaultDevice = deviceProvider.DefaultDevice;
+					if(this.defaultDevice != null)
+					{
+                        this.masterVolume = this.defaultDevice.Master.Volume;
+                        this.defaultDevice.ProcessCreated += OnProcessCreated;
+						this.defaultDevice.Master.PropertyChanged += OnMasterPropertyChanged;
+					}
+				}
+				else
+				{
+					this.deviceProvider.DefaultDeviceChanged -= OnDefaultDeviceChanged;
+					if(this.defaultDevice != null)
+					{
+						this.defaultDevice.ProcessCreated -= OnProcessCreated;
+					}
+					this.defaultDevice = null;
+				}
+				if(SettingsProvider.Settings.SyncAppVolumeIsOn != value)
+				{
+					Task.Run(() =>
+					{
+						if(isOn)
+							Logger.Info($"Synchronising Application volume to Master volume on change.");
+						SettingsProvider.Settings.SyncAppVolumeIsOn = value;
+						_ = SettingsProvider.SaveSettings();
+					});
+				}
+				OnPropertyChanged();
+			}
+		}
+
+		private readonly IDeviceProvider deviceProvider;
+		private OutputDeviceModel defaultDevice;
+
+		private ILog _logger;
+		private ILog Logger => _logger ??= LogManager.GetLogger(typeof(AppVolumeSyncViewModel));
+
+		public AppVolumeSyncViewModel()
+		{
+			this.deviceProvider = DeviceProvider.GetInstance();
+			this.IsOn = SettingsProvider.Settings.SyncAppVolumeIsOn;
+		}
+
+        private void SyncSessionVolume()
+        {
+			if (this.IsOn)
+			{
+				foreach (var process in this.defaultDevice.Processes)
+				{
+					if (process.Volume != this.MasterVolume)
+					{
+						process.SetVolume(this.MasterVolume, false, ref GuidValue.Internal.VolumeGUID);
+					}
+				}
+			}
+        }
+
+        private void OnDefaultDeviceChanged(OutputDeviceModel newDevice)
+		{
+			if(this.defaultDevice != null)
+				this.defaultDevice.ProcessCreated -= OnProcessCreated;
+			this.defaultDevice = newDevice;
+			if(this.IsOn && newDevice != null)
+			{
+				newDevice.ProcessCreated += OnProcessCreated;
+				masterVolume = newDevice.Master.Volume;
+				SyncSessionVolume();
+			}
+		}
+
+		private void OnProcessCreated(AudioProcessModel newProcess)
+		{
+			if(this.IsOn && newProcess.Volume != this.MasterVolume)
+				newProcess.Volume = this.MasterVolume;
+		}
+
+        private void OnMasterPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+			if (sender is MasterSessionModel && e.PropertyName == nameof(MasterSessionModel.Volume))
+			{
+				this.masterVolume = ((MasterSessionModel)sender).Volume;
+				SyncSessionVolume();
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+		private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
+}

--- a/Volumey/ViewModel/Settings/AppVolumeSyncViewModel.cs
+++ b/Volumey/ViewModel/Settings/AppVolumeSyncViewModel.cs
@@ -70,13 +70,13 @@ namespace Volumey.ViewModel.Settings
 
         private void SyncSessionVolume()
         {
-			if (this.IsOn)
+			if(this.IsOn)
 			{
 				foreach (var process in this.defaultDevice.Processes)
 				{
-					if (process.Volume != this.MasterVolume)
+					if(process.Volume != this.MasterVolume)
 					{
-						process.SetVolume(this.MasterVolume, false, ref GuidValue.Internal.VolumeGUID);
+						process.Volume = this.MasterVolume;
 					}
 				}
 			}
@@ -103,9 +103,9 @@ namespace Volumey.ViewModel.Settings
 
         private void OnMasterPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-			if (sender is MasterSessionModel && e.PropertyName == nameof(MasterSessionModel.Volume))
+			if(sender is MasterSessionModel masterSession && e.PropertyName == nameof(MasterSessionModel.Volume))
 			{
-				this.masterVolume = ((MasterSessionModel)sender).Volume;
+				this.masterVolume = masterSession.Volume;
 				SyncSessionVolume();
             }
         }

--- a/Volumey/ViewModel/SettingsViewModel.cs
+++ b/Volumey/ViewModel/SettingsViewModel.cs
@@ -15,6 +15,7 @@ namespace Volumey.ViewModel
         public AppsHotkeysViewModel HotkeysViewModel { get; }
         public OpenHotkeyViewModel OpenHotkeyViewModel { get; }
         public VolumeLimitViewModel VolumeLimitViewModel { get; }
+        public AppVolumeSyncViewModel AppVolumeSyncViewModel { get; }
         public DefaultDeviceHotkeysViewModel DefaultDeviceHotkeysViewModel { get; }
         public NotificationViewModel NotificationsViewModel { get; }
         public ForegroundWindowVolumeViewModel ForegroundWindowVolumeViewModel { get; }
@@ -71,6 +72,7 @@ namespace Volumey.ViewModel
             this.DeviceVolumeHotkeysViewModel = new DeviceVolumeHotkeysViewModel();
             this.OpenHotkeyViewModel = new OpenHotkeyViewModel();
             this.VolumeLimitViewModel = new VolumeLimitViewModel();
+            this.AppVolumeSyncViewModel = new AppVolumeSyncViewModel();
             this.DefaultDeviceHotkeysViewModel = new DefaultDeviceHotkeysViewModel();
             this.ForegroundWindowVolumeViewModel = new ForegroundWindowVolumeViewModel();
             this.NotificationsViewModel = new NotificationViewModel();


### PR DESCRIPTION
"Some" device manufacturers (i.e. SoundBlaster) don't support volume control on Dolby Digital output streams, effectively rendering the Windows volume slider to only On or Off 😭 
Changing the application volume, before it's mixed to Dolby Digital is the only available workaround, and it is clunky at best, but it does allow software volume control. 
A closed-source application used to exist that tied Master Volume changes to all applications running - alas the app is no longer available, so I ported the feature to Volumey, since it looked pretty easy to extend (It was! Thank you for your app!)

I'll understand if you're not interested in merging this - but I think a lot of Soundblaster X3/X6 owners would love you forever if you did!

More info here:

https://www.reddit.com/r/SoundBlasterOfficial/comments/m84d75/soundblaster_x3_no_volume_control_when_dolby/
https://www.reddit.com/r/SoundBlasterOfficial/comments/hn03us/autovolumecontrol_a_tool_that_helps_you_control/ (Defunct)

Basic testing is done - this will probably have an odd effect if you don't have a sound card affected by the issue 🤔 