### PR TITLE
Show OSD notification when default device changed

### DIFF
--- a/Volumey/Helper/NotificationManagerHelper.cs
+++ b/Volumey/Helper/NotificationManagerHelper.cs
@@ -22,6 +22,7 @@ namespace Volumey.Helper
 		private static ILog _logger;
 		private static ILog Logger => _logger ??= LogManager.GetLogger(typeof(NotificationManagerHelper));
 
+		private static string _lastDisplayedSessionId = string.Empty;
 		private static HashSet<string> _displayedNotificationKeys = new HashSet<string>();
 		static NotificationManagerHelper()
 		{
@@ -41,12 +42,17 @@ namespace Volumey.Helper
 				if(_notificationManager.IsDisplayed(session.Id, resetDisplayTimer: true))
 					return;
 
-				// when switch session, other displayed session notification should be closed.
-				foreach(var key in _displayedNotificationKeys)
+				if(string.IsNullOrEmpty(_lastDisplayedSessionId) == false && _lastDisplayedSessionId != session.Id)
 				{
-					_notificationManager.CloseNotification(key);
+					// when switch session, other displayed session notification should be closed.
+					foreach(var key in _displayedNotificationKeys)
+					{
+						_notificationManager.CloseNotification(key);
+					}
+					_displayedNotificationKeys.Clear();
 				}
-				_displayedNotificationKeys.Clear();
+				//record last displayed id
+				_lastDisplayedSessionId = session.Id;
 
 				var content = new VolumeNotificationContent(session);
 				_displayedNotificationKeys.Add(session.Id);

--- a/Volumey/Helper/NotificationManagerHelper.cs
+++ b/Volumey/Helper/NotificationManagerHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using log4net;
 using Notification.Wpf;
 using Notification.Wpf.Controls;
@@ -21,6 +22,7 @@ namespace Volumey.Helper
 		private static ILog _logger;
 		private static ILog Logger => _logger ??= LogManager.GetLogger(typeof(NotificationManagerHelper));
 
+		private static HashSet<string> _displayedNotificationKeys = new HashSet<string>();
 		static NotificationManagerHelper()
 		{
 			_notificationManager = new NotificationManager();
@@ -38,7 +40,16 @@ namespace Volumey.Helper
 			{
 				if(_notificationManager.IsDisplayed(session.Id, resetDisplayTimer: true))
 					return;
+
+				// when switch session, other displayed session notification should be closed.
+				foreach(var key in _displayedNotificationKeys)
+				{
+					_notificationManager.CloseNotification(key);
+				}
+				_displayedNotificationKeys.Clear();
+
 				var content = new VolumeNotificationContent(session);
+				_displayedNotificationKeys.Add(session.Id);
 				_notificationManager.ShowNotification(content, session.Id, true, NotificationDisplayTime);
 			}
 			catch(ObjectDisposedException) { }

--- a/Volumey/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Volumey/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>x64</Platform>
+    <PublishDir>bin\x64\Release\netcoreapp3.1\win-x64\publish\win-x64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>false</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+  </PropertyGroup>
+</Project>

--- a/Volumey/Properties/PublishProfiles/FolderProfile.pubxml.user
+++ b/Volumey/Properties/PublishProfiles/FolderProfile.pubxml.user
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <History>True|2023-07-27T02:01:33.5278036Z;True|2023-07-27T09:58:49.9533175+08:00;True|2023-07-27T09:58:11.5212365+08:00;</History>
+    <LastFailureDetails />
+  </PropertyGroup>
+</Project>

--- a/Volumey/View/MainView.Updater.cs
+++ b/Volumey/View/MainView.Updater.cs
@@ -28,6 +28,7 @@ namespace Volumey.View
 
 		private async Task CheckForUpdate()
 		{
+			return;
 			AutoUpdater.ShowSkipButton = false;
 			AutoUpdater.ReportErrors = false;
 			AutoUpdater.LetUserSelectRemindLater = false;

--- a/Volumey/ViewModel/Settings/AppsHotkeysViewModel.cs
+++ b/Volumey/ViewModel/Settings/AppsHotkeysViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -170,7 +171,8 @@ namespace Volumey.ViewModel.Settings
 			{
 				this.DefaultDevice.ProcessCreated += OnProcessStarted;
 				this.FindAndSetupRegisteredHotkeys();
-			}
+            }
+			ProcessStateMediator.NotifyAudioStateChange(this.DefaultDevice.Master);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Like #50 issue said, it will show notification when default device changed. 

when I watch the notification, it's not clear to distinguish which device is the default now, because two notification is shown at the same time. so,I close previous notification when session changed.

It looks perfect now.